### PR TITLE
Add 'Product Watch' to SaaS directory list

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Finding where to launch your SaaS can be tedious. This directory aims to save fo
 | 94 | **gh/awesome-aussie**                  | A primary tech directory for Australian-based startups and open-source projects.                        | [Submit Here](https://github.com/AdamXweb/awesome-aussie)                  |
 | 95 | **AgentMRR**                        | A public revenue leaderboard and verification platform for AI agents with provider-backed proof.           | [Submit Here](https://agentmrr.com/dashboard/agents)                      |
 | 96 | **StartupLibrary**                  | A startup community built to launch your startup, climb the leaderboard, and grow with built-in SEO and marketing tools. | [Submit Here](https://startuplibrary.net/submit)                          |
+| 97 | **Product Watch**                   | Your Daily Feed of New Tech Products & Startups| [Submit Here](https://productwatch.io/) |
+
+
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Finding where to launch your SaaS can be tedious. This directory aims to save fo
 | 94 | **gh/awesome-aussie**                  | A primary tech directory for Australian-based startups and open-source projects.                        | [Submit Here](https://github.com/AdamXweb/awesome-aussie)                  |
 | 95 | **AgentMRR**                        | A public revenue leaderboard and verification platform for AI agents with provider-backed proof.           | [Submit Here](https://agentmrr.com/dashboard/agents)                      |
 | 96 | **StartupLibrary**                  | A startup community built to launch your startup, climb the leaderboard, and grow with built-in SEO and marketing tools. | [Submit Here](https://startuplibrary.net/submit)                          |
-| 97 | **Product Watch**                   | Your Daily Feed of New Tech Products & Startups| [Submit Here](https://productwatch.io/) |
+| 97 | **Product Watch**                   | A daily feed of new tech products and startups where makers can launch their latest projects. | [Submit Here](https://productwatch.io/product/create) |
 
 
 


### PR DESCRIPTION
Add 'Product Watch' to the list of SaaS directories in README.

## Description
Product Watch is a community-driven platform for discovering the latest tech products, apps, startups, and innovations. Vote, discuss, and explore what's new and trending every day.

## Checklist
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
- [X] I have added the directory to the **bottom** of the list.
- [X] I have verified the link works and goes directly to the submission page.
- [X] The description is objective and without marketing fluff.
- [X] If submitting a Reddit, X, or Facebook community, I have added the appropriate prefix (`r/`, `x/`, `fb/`) and understand only these three platforms are currently accepted for communities.
