### PR TITLE
Add Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ While this markdown list is a great reference, browsing a table on GitHub and su
 | 156 | **Revispy Launchpad** | A product launch and project showcase platform for builders to share side projects, collect feedback, and connect with the tech community. | [Submit Here](https://www.revispy.com/launchpad/create?utm_source=launchdb.vercel.app&via=launchdb) |
 | 157 | **r/AISaaSHunter** | A Reddit community dedicated to discovering, discussing, and promoting AI-powered SaaS tools. | [Submit Here](https://www.reddit.com/r/AISaaSHunter/submit/?utm_source=launchdb.vercel.app&via=launchdb) |
 | 158 | **JustLaunched** | A directory where founders submit and discover newly launched SaaS products, organized by category. | [Submit Here](https://justlaunched.fyi/submit?utm_source=launchdb.vercel.app&via=launchdb) |
-| - | **Open Source Projects** | A directory where makers submit and discover open source projects and open source alternatives to proprietary software, organized by category. | [Submit Here](https://opensourceprojects.cc/submit) |
+| - | **Open Source Projects** | A categorized directory where makers submit and discover open-source projects and alternatives to proprietary software. | [Submit Here](https://opensourceprojects.cc/submit) |
 
 ## 🤝 How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ While this markdown list is a great reference, browsing a table on GitHub and su
 | 156 | **Revispy Launchpad** | A product launch and project showcase platform for builders to share side projects, collect feedback, and connect with the tech community. | [Submit Here](https://www.revispy.com/launchpad/create?utm_source=launchdb.vercel.app&via=launchdb) |
 | 157 | **r/AISaaSHunter** | A Reddit community dedicated to discovering, discussing, and promoting AI-powered SaaS tools. | [Submit Here](https://www.reddit.com/r/AISaaSHunter/submit/?utm_source=launchdb.vercel.app&via=launchdb) |
 | 158 | **JustLaunched** | A directory where founders submit and discover newly launched SaaS products, organized by category. | [Submit Here](https://justlaunched.fyi/submit?utm_source=launchdb.vercel.app&via=launchdb) |
+| - | **Open Source Projects** | A directory where makers submit and discover open source projects and open source alternatives to proprietary software, organized by category. | [Submit Here](https://opensourceprojects.cc/submit) |
 
 ## 🤝 How to Contribute
 


### PR DESCRIPTION
Adds **Open Source Projects** to the bottom of the directory table, per CONTRIBUTING.md:

- Added at the bottom of the table with `-` in the # column
- Submit Link points directly to the submission page: https://opensourceprojects.cc/submit
- One-sentence objective description

It's a directory where makers submit and discover open source projects and open source alternatives to proprietary software — same category as the existing OpenAlternative / AlternativeTo / SaaSHub entries.