### PR TITLE
Add SaaSCity

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ While this markdown list is a great reference, browsing a table on GitHub and su
 | 157 | **r/AISaaSHunter** | A Reddit community dedicated to discovering, discussing, and promoting AI-powered SaaS tools. | [Submit Here](https://www.reddit.com/r/AISaaSHunter/submit/?utm_source=launchdb.vercel.app&via=launchdb) |
 | 158 | **JustLaunched** | A directory where founders submit and discover newly launched SaaS products, organized by category. | [Submit Here](https://justlaunched.fyi/submit?utm_source=launchdb.vercel.app&via=launchdb) |
 | 159 | **Open Source Projects** | A categorized directory where makers submit and discover open-source projects and alternatives to proprietary software. | [Submit Here](https://opensourceprojects.cc/submit?utm_source=launchdb.vercel.app&via=launchdb) |
-| - | **SaaSCity** | A gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map. | [Submit Here](https://saascity.io/submit) |
+| - | **SaaSCity** | A gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map. | [Submit Here](https://saascity.io/saascity?submit=1) |
 
 ## 🤝 How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ While this markdown list is a great reference, browsing a table on GitHub and su
 | 157 | **r/AISaaSHunter** | A Reddit community dedicated to discovering, discussing, and promoting AI-powered SaaS tools. | [Submit Here](https://www.reddit.com/r/AISaaSHunter/submit/?utm_source=launchdb.vercel.app&via=launchdb) |
 | 158 | **JustLaunched** | A directory where founders submit and discover newly launched SaaS products, organized by category. | [Submit Here](https://justlaunched.fyi/submit?utm_source=launchdb.vercel.app&via=launchdb) |
 | 159 | **Open Source Projects** | A categorized directory where makers submit and discover open-source projects and alternatives to proprietary software. | [Submit Here](https://opensourceprojects.cc/submit?utm_source=launchdb.vercel.app&via=launchdb) |
+| - | **SaaSCity** | A gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map. | [Submit Here](https://saascity.io/submit) |
 
 ## 🤝 How to Contribute
 


### PR DESCRIPTION
Adds **SaaSCity** — a gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map.

Checklist against CONTRIBUTING.md:
- [x] **Relevant** — founders can submit and list a SaaS product
- [x] **Active** — live, and every submission is manually reviewed (usually approved within 24h)
- [x] **Objective description** — no marketing fluff
- [x] **Direct submission link** — https://saascity.io/submit (not the homepage)
- [x] **Added to the bottom** of the table
- [x] **`-` in the `#` column** for the bot to number

Free listing gives an indexed product page; paid tiers add a dofollow backlink and map placement. Ahrefs DR 46.