### PR TITLE
Add Phyco

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ While this markdown list is a great reference, browsing a table on GitHub and su
 | 171 | **Alt Hunt** | A directory and comparison platform where founders publish software alternative pages to capture competitor search traffic. | 4 | [Submit Here](https://althunt.io/new?utm_source=launchdb.vercel.app&via=launchdb) |
 | 172 | **SaaSBoard** | An interactive visual grid directory where SaaS founders can claim tiles to showcase their products and gain early traction. | 0 | [Submit Here](https://saasboard.app/?utm_source=launchdb.vercel.app&via=launchdb) |
 | 173 | **Outbid** | A pay-to-rank leaderboard platform where makers and founders bid to showcase products and gain top visibility. | 20 | [Submit Here](https://outbid.lol/?utm_source=launchdb.vercel.app&via=launchdb) |
+| - | **Phyco** | A website catalogue with verified user reviews across 16 categories, with free moderated listings. | - | [Submit Here](https://phyco.org/submit) |
 
 *Domain Rating data is provided by [Domain Rating by Ahrefs](https://ahrefs.com/).*
 


### PR DESCRIPTION
Adding [Phyco](https://phyco.org) - a website catalogue with verified user reviews across 16 categories (AI, finance, design, utilities and more).

Per the contribution guidelines: added to the bottom of the table, `-` in the # and Domain Rating columns, direct submission link (free, no account required, human moderation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014aTConZcDTh57KMn39s5Xd